### PR TITLE
feat: Prevent subscriber duplication

### DIFF
--- a/src/Observable/index.ts
+++ b/src/Observable/index.ts
@@ -2,20 +2,20 @@ type Observer<T> = (data: T) => void
 type Subscriber<T> = Observer<T>
 
 class Observable<T> {
-  observers: Observer<T>[]
+  observers: Set<Observer<T>>
   value: any
 
   constructor(value: T) {
-    this.observers = []
+    this.observers = new Set()
     this.value = value
   }
 
   subscribe(subscriber: Subscriber<T>) {
-    this.observers.push(subscriber)
+    this.observers.add(subscriber)
   }
 
   unsubscribe(subscriber: Subscriber<T>) {
-    this.observers = this.observers.filter((observer) => observer !== subscriber)
+    this.observers.delete(subscriber)
   }
 
   get(): T {


### PR DESCRIPTION
The purpose of this change is to prevent the same subscriber being added twice to the the observable and later called twice by replacing the `Array` with a `Set`